### PR TITLE
changed name of application to print-file

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 env:
-  IMAGE: ras-rm-print-file
+  IMAGE: print-file
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
   ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET }}
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  IMAGE: ras-rm-print-file
+  IMAGE: print-file
   REGISTRY_HOSTNAME: eu.gcr.io
   HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
   RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}

--- a/_infra/helm/ras-rm-print-file/Chart.yaml
+++ b/_infra/helm/ras-rm-print-file/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.0
 
-appVersion: 1.0.3
+appVersion: 1.0.4

--- a/_infra/helm/ras-rm-print-file/Chart.yaml
+++ b/_infra/helm/ras-rm-print-file/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: ras-rm-print-file
+name: print-file
 description: A Helm chart for deploying the rasrm print file generator
 
 type: application


### PR DESCRIPTION
## Context
Changed the name of the application from `ras-rm-print-file` to `print-file` in order to match the naming scheme of the other services.

## Changes
* Modified chart.yaml, main.yml, and comment.yml to have application/image name as `print-file`.

## Links
[Trello card](https://trello.com/c/chBucjum/69-s19-deploy-ras-rm-print-file-to-production-2)