### PR TITLE
JSON Payload to GCS, SFTP fixes and Rest API removal

### DIFF
--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.0
 
-appVersion: 1.0.6
+appVersion: 1.0.7

--- a/_infra/helm/print-file/values.yaml
+++ b/_infra/helm/print-file/values.yaml
@@ -23,7 +23,7 @@ log:
   level: debug
 
 sftp:
-  directory: /home/demo/sftp
+  directory: .
   test:
     enabled: true
 

--- a/cmd/ras-rm-print-file/main.go
+++ b/cmd/ras-rm-print-file/main.go
@@ -42,7 +42,6 @@ func main() {
 	//configure the gorilla router
 	r := mux.NewRouter()
 	r.Use(web.Middleware)
-	r.HandleFunc("/print/{filename}", web.Print)
 	r.HandleFunc("/alive", web.Alive)
 	r.HandleFunc("/ready", web.Ready)
 	http.Handle("/", r)

--- a/internal/gcpubsub/subscribe.go
+++ b/internal/gcpubsub/subscribe.go
@@ -34,8 +34,7 @@ func (s Subscriber) subscribe(ctx context.Context, client *pubsub.Client) {
 	log.Debug("waiting to receive")
 	err := sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
 		log.Info("print file received - processing")
-		log.WithField("data", string(msg.Data)).Debug("print file data")
-
+		
 		if msg.DeliveryAttempt != nil {
 			log.WithField("delivery attempts", *msg.DeliveryAttempt).Info("Message delivery attempted")
 		}

--- a/internal/payload/save.go
+++ b/internal/payload/save.go
@@ -1,0 +1,38 @@
+package payload
+
+import (
+	"github.com/ONSdigital/ras-rm-print-file/internal/gcs"
+	"github.com/ONSdigital/ras-rm-print-file/pkg"
+	log "github.com/sirupsen/logrus"
+	"path"
+	"strings"
+)
+
+type Payload struct {
+	gcsUpload pkg.Upload
+}
+
+func Create() Payload {
+	payload := Payload{}
+	payload.gcsUpload = &gcs.GCSUpload{}
+	return payload
+}
+
+// This function saves the payload (pre-templating) to the bucket for safe keeping and monitoring
+func (p Payload) Save(filename string, payload []byte) {
+	//rename file to .json
+	payloadFileName := strings.TrimSuffix(filename, path.Ext(filename)) + ".json"
+	log.WithField("payloadFileName", payloadFileName).Info("saving json payload to GCS")
+	err := p.gcsUpload.Init()
+	if err != nil {
+		log.WithError(err).Error("unable to initialise gcs connection")
+		return
+	}
+	defer p.gcsUpload.Close()
+	err = p.gcsUpload.UploadFile(payloadFileName, payload)
+	if err != nil {
+		log.WithError(err).Error("unable to upload json payload")
+		return
+	}
+	log.Info("saved json payload")
+}

--- a/internal/payload/save_test.go
+++ b/internal/payload/save_test.go
@@ -1,0 +1,25 @@
+package payload
+
+import (
+	mocks "github.com/ONSdigital/ras-rm-print-file/mocks/pkg"
+	"testing"
+)
+
+func TestSave(t *testing.T) {
+
+	data := []byte("test")
+	filename := "test.csv"
+
+	gcsUpload := new(mocks.Upload)
+	gcsUpload.On("Init").Return(nil)
+	gcsUpload.On("UploadFile", "test.json", data).Return(nil)
+	gcsUpload.On("Close").Return(nil)
+
+	payload := Payload{
+		gcsUpload,
+	}
+	payload.Save(filename, data)
+
+	gcsUpload.AssertCalled(t, "UploadFile", "test.json", data)
+	gcsUpload.AssertExpectations(t)
+}

--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -28,11 +28,6 @@ func Create() *SDCPrinter {
 	return processor
 }
 
-func CreateAndProcess(filename string, printFile *pkg.PrintFile) error {
-	processor := Create()
-	return processor.Process(filename, printFile)
-}
-
 func (p *SDCPrinter) Process(filename string, pf *pkg.PrintFile) error {
 	log.WithField("filename", filename).Info("processing print file")
 
@@ -132,6 +127,7 @@ func upload(filename string, buffer *bytes.Buffer, uploader pkg.Upload, name str
 		log.WithError(err).Errorf("failed to initialise %v upload", name)
 		return false
 	}
+	defer uploader.Close()
 	err = uploader.UploadFile(filename, buffer.Bytes())
 	if err != nil {
 		log.WithError(err).Errorf("failed to upload to %v", name)

--- a/internal/processor/printer_test.go
+++ b/internal/processor/printer_test.go
@@ -26,10 +26,12 @@ func TestProcess(t *testing.T) {
 	gcsUpload := new(mocks.Upload)
 	gcsUpload.On("Init").Return(nil)
 	gcsUpload.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
+	gcsUpload.On("Close").Return(nil)
 
 	sftpUpload := new(mocks.Upload)
 	sftpUpload.On("Init").Return(nil)
 	sftpUpload.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
+	sftpUpload.On("Close").Return(nil)
 
 	processor := &SDCPrinter{
 		store,

--- a/internal/sftp/sftp_upload.go
+++ b/internal/sftp/sftp_upload.go
@@ -67,24 +67,30 @@ func (s *SFTPUpload) UploadFile(filename string, contents []byte) error {
 	path := filepath(filename)
 
 	log.Info("creating file")
+	workdir, err := client.Getwd()
+	if err != nil {
+		log.Error("unable to get current working directory")
+	}
+
+	log.WithField("workdir", workdir).Info("working dir")
+
 	f, err := client.Create(path)
 	if err != nil {
-		log.WithError(err).Error("unable to create file")
+		log.WithError(err).WithField("filepath", path).Error("unable to create file")
 		return err
 	}
 	log.Info("writing contents")
 	if _, err := f.Write(contents); err != nil {
-		log.WithError(err).Error("unable to write file contents")
+		log.WithError(err).WithField("filepath", path).Error("unable to write file contents")
 		return err
 	}
 	f.Close()
 
 	// check it's there
 	log.Info("confirming file exists")
-	fi, err := client.Lstat(filename)
+	fi, err := client.Lstat(path)
 	if err != nil {
-		log.WithError(err).Error("unable to write file contents")
-		return err
+		log.WithError(err).WithField("filepath", path).Warn("unable to confirm file exists")
 	}
 	log.WithField("file", fi.Name()).Info("upload complete")
 	return nil

--- a/internal/web/rest.go
+++ b/internal/web/rest.go
@@ -1,13 +1,8 @@
 package web
 
 import (
-	"encoding/json"
 	"fmt"
-	"github.com/ONSdigital/ras-rm-print-file/internal/processor"
-	"github.com/ONSdigital/ras-rm-print-file/pkg"
-	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -17,46 +12,6 @@ func Middleware(next http.Handler) http.Handler {
 		w.Header().Add("Content-Type", "application/json")
 		next.ServeHTTP(w, r)
 	})
-}
-
-func Print(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case "POST":
-		log.Debug("post request received processing")
-		reqBody, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.WithError(err).Error("unable to read body")
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		log.WithField("reqBody", string(reqBody)).Debug("body of request")
-		vars := mux.Vars(r)
-		filename := vars["filename"]
-		if filename == "" {
-			w.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintln(w, "missing filename")
-		}
-		log.WithField("filename", filename).Info("received request to print file")
-		var printFileEntries []*pkg.PrintFileEntry
-		err = json.Unmarshal(reqBody, &printFileEntries)
-		if err != nil {
-			log.WithError(err).Error("unable to marshall json payload")
-			w.WriteHeader(http.StatusBadRequest)
-		}
-		printFile := pkg.PrintFile{
-			PrintFiles: printFileEntries,
-		}
-
-		w.WriteHeader(http.StatusAccepted)
-		resp, _ := json.Marshal(printFile)
-		log.WithField("resp", string(resp)).Debug("about to process")
-		//spawn a process to process the print file
-
-		go processor.CreateAndProcess(filename, &printFile)
-	default:
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		log.Info("print - method not allowed")
-		fmt.Fprintf(w, "Only POST methods are supported.")
-	}
 }
 
 func Alive(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/rest.go
+++ b/internal/web/rest.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/ONSdigital/ras-rm-print-file/internal/gcs"
 	"github.com/ONSdigital/ras-rm-print-file/internal/processor"
 	"github.com/ONSdigital/ras-rm-print-file/pkg"
 	"github.com/gorilla/mux"
@@ -28,6 +29,9 @@ func Print(w http.ResponseWriter, r *http.Request) {
 			log.WithError(err).Error("unable to read body")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
+
+
+
 		log.WithField("reqBody", string(reqBody)).Debug("body of request")
 		vars := mux.Vars(r)
 		filename := vars["filename"]
@@ -37,6 +41,7 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		}
 		log.WithField("filename", filename).Info("received request to print file")
 		var printFileEntries []*pkg.PrintFileEntry
+
 		err = json.Unmarshal(reqBody, &printFileEntries)
 		if err != nil {
 			log.WithError(err).Error("unable to marshall json payload")
@@ -49,6 +54,8 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		resp, _ := json.Marshal(printFile)
 		log.WithField("resp", string(resp)).Debug("about to process")
+		uploadBodyToGCS(reqBody, filename)
+
 		//spawn a process to process the print file
 
 		go processor.CreateAndProcess(filename, &printFile)
@@ -57,6 +64,15 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		log.Info("print - method not allowed")
 		fmt.Fprintf(w, "Only POST methods are supported.")
 	}
+}
+
+func uploadBodyToGCS(reqBody []byte, filename string) {
+	copyOfBody := make([]byte, len(reqBody))
+	copy(copyOfBody, reqBody)
+	copyFilename := filename + ".json"
+	gcsUpload := gcs.GCSUpload{}
+	gcsUpload.Init()
+	gcsUpload.UploadFile(copyFilename, copyOfBody)
 }
 
 func Alive(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/rest.go
+++ b/internal/web/rest.go
@@ -3,7 +3,6 @@ package web
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ONSdigital/ras-rm-print-file/internal/gcs"
 	"github.com/ONSdigital/ras-rm-print-file/internal/processor"
 	"github.com/ONSdigital/ras-rm-print-file/pkg"
 	"github.com/gorilla/mux"
@@ -29,9 +28,6 @@ func Print(w http.ResponseWriter, r *http.Request) {
 			log.WithError(err).Error("unable to read body")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-
-
-
 		log.WithField("reqBody", string(reqBody)).Debug("body of request")
 		vars := mux.Vars(r)
 		filename := vars["filename"]
@@ -41,7 +37,6 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		}
 		log.WithField("filename", filename).Info("received request to print file")
 		var printFileEntries []*pkg.PrintFileEntry
-
 		err = json.Unmarshal(reqBody, &printFileEntries)
 		if err != nil {
 			log.WithError(err).Error("unable to marshall json payload")
@@ -54,8 +49,6 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		resp, _ := json.Marshal(printFile)
 		log.WithField("resp", string(resp)).Debug("about to process")
-		uploadBodyToGCS(reqBody, filename)
-
 		//spawn a process to process the print file
 
 		go processor.CreateAndProcess(filename, &printFile)
@@ -64,15 +57,6 @@ func Print(w http.ResponseWriter, r *http.Request) {
 		log.Info("print - method not allowed")
 		fmt.Fprintf(w, "Only POST methods are supported.")
 	}
-}
-
-func uploadBodyToGCS(reqBody []byte, filename string) {
-	copyOfBody := make([]byte, len(reqBody))
-	copy(copyOfBody, reqBody)
-	copyFilename := filename + ".json"
-	gcsUpload := gcs.GCSUpload{}
-	gcsUpload.Init()
-	gcsUpload.UploadFile(copyFilename, copyOfBody)
 }
 
 func Alive(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
1. Save the JSON payload received from Action Exporter to GCS. This will aid in monitoring and resilience.
2. Fix the SFTP when using the test container, it doesn't need the directory there.
3. The SFTP check file exist method was not checking the file path
4. Remove the REST api for uploading a payload, this is not needed as it will be pub/sub only.