### PR TITLE
SFTP check if file exists before writing

### DIFF
--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.0
 
-appVersion: 1.0.7
+appVersion: 1.0.8

--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -153,7 +153,6 @@ func sanitise(pf *pkg.PrintFile) {
 
 func nullIfEmpty(value string) string {
 	if value == "" {
-		log.Debug("empty value replacing with null")
 		return "null"
 	}
 	return value

--- a/internal/sftp/sftp_upload.go
+++ b/internal/sftp/sftp_upload.go
@@ -74,6 +74,17 @@ func (s *SFTPUpload) UploadFile(filename string, contents []byte) error {
 
 	log.WithField("workdir", workdir).Info("working dir")
 
+	//check the file is there
+	fi, err := client.Lstat(path)
+	if err != nil {
+		log.WithField("filepath", path).Info("file does not exist, creating")
+	} else {
+		if fi.Size() != 0 {
+			log.WithField("filepath", path).Info("file already exists and is not empty")
+			return nil
+		}
+	}
+
 	f, err := client.Create(path)
 	if err != nil {
 		log.WithError(err).WithField("filepath", path).Error("unable to create file")
@@ -88,7 +99,7 @@ func (s *SFTPUpload) UploadFile(filename string, contents []byte) error {
 
 	// check it's there
 	log.Info("confirming file exists")
-	fi, err := client.Lstat(path)
+	fi, err = client.Lstat(path)
 	if err != nil {
 		log.WithError(err).WithField("filepath", path).Warn("unable to confirm file exists")
 	}


### PR DESCRIPTION
It's possible for the file to be transferred to the SFTP server but get an error from MoveIt. In this scenario the retry fails as it can't overwrite the file.