### PR TITLE
Remove old entries

### DIFF
--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.1
 
-appVersion: 1.0.28
+appVersion: 1.0.29

--- a/_infra/helm/print-file/templates/deployment.yaml
+++ b/_infra/helm/print-file/templates/deployment.yaml
@@ -85,6 +85,10 @@ spec:
               value: "{{ .Values.sftp.directory }}"
             - name: RETRY_DELAY
               value: "{{ .Values.retry.delay }}"
+            - name: CLEANUP_DELAY
+              value: "{{ .Values.cleanup.delay }}"
+            - name: CLEANUP_RETENTION
+              value: "{{ .Values.cleanup.duration }}"
             - name: PUBSUB_TOPIC
               value: {{ .Values.gcp.topic }}
             - name: PUBSUB_SUB_ID

--- a/_infra/helm/print-file/values.yaml
+++ b/_infra/helm/print-file/values.yaml
@@ -41,6 +41,10 @@ sftp:
 retry:
   delay: 3600000
 
+cleanup:
+  delay: 24
+  duration: 720
+
 gcp:
   project: ras-rm-sandbox
   bucket:

--- a/cmd/ras-rm-print-file/main.go
+++ b/cmd/ras-rm-print-file/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/ONSdigital/ras-rm-print-file/internal/database"
 	"net/http"
 
 	"github.com/ONSdigital/ras-rm-print-file/internal/config"
@@ -26,6 +27,13 @@ func startRetryService() {
 	logger.Info("started retry service")
 }
 
+func startCleanUpService() {
+	logger.Info("starting clean up service")
+	cu := database.CleanUp{}
+	cu.Start()
+	logger.Info("started clean up service")
+}
+
 func startPubSubListener() {
 	logger.Info("starting gcpubsub listener")
 	s := gcpubsub.Subscriber{
@@ -48,6 +56,7 @@ func main() {
 
 	go startRetryService()
 	go startPubSubListener()
+	go startCleanUpService()
 
 	logger.Info("started")
 	if err := http.ListenAndServe(":8080", nil); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ func SetDefaults() {
 	viper.SetDefault("SFTP_PASSWORD", "sftp")
 	viper.SetDefault("SFTP_DIRECTORY", "printfiles")
 	viper.SetDefault("RETRY_DELAY", "3600000")
+	viper.SetDefault("CLEANUP_DELAY", "24")
+	viper.SetDefault("CLEANUP_RETENTION", "720")
 	viper.SetDefault("PUBSUB_SUB_ID", "print-file-workers")
 	viper.SetDefault("PUB_SUB_TOPIC", "print-file-jobs")
 }

--- a/internal/database/cleanup.go
+++ b/internal/database/cleanup.go
@@ -60,6 +60,7 @@ func (c CleanUp) process() {
 			retentionDuration := time.Duration(retention) * time.Hour
 			if duration >= retentionDuration {
 				logger.Info("deleting print file request as its older than retention period",
+					zap.String("printFileName", printRequest.PrintFilename),
 					zap.Duration("retention", retentionDuration),
 					zap.Duration("duration ", duration))
 				c.store.Delete(printRequest)

--- a/internal/database/cleanup.go
+++ b/internal/database/cleanup.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	logger "github.com/ONSdigital/ras-rm-print-file/logging"
+	"github.com/ONSdigital/ras-rm-print-file/pkg"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+	"time"
+)
+
+type CleanUp struct {
+	store   pkg.Store
+}
+
+func (c CleanUp) Start() {
+	configDelay := viper.GetInt64("CLEANUP_DELAY")
+	logger.Debug("retrieving clean up delay setting from config",
+		zap.Int64("delay", configDelay))
+
+	delay := time.Duration(configDelay) * time.Hour
+	for {
+		logger.Info("about to run clean up service")
+		c.store = &DataStore{}
+		logger.Info("sleeping clean up service",
+			zap.String("delay", delay.String()))
+		time.Sleep(delay)
+	}
+}
+
+func (c CleanUp) process() {
+	err := c.store.Init()
+	defer c.store.Close()
+	if err != nil {
+		logger.Error("unable to initialise storage",
+			zap.Error(err))
+		return
+	}
+	printRequests, err := c.store.FindComplete()
+	if err != nil {
+		logger.Error("unable to find completed print file requests",
+			zap.Error(err))
+		return
+	}
+	if printRequests == nil {
+		logger.Info("no completed print file requests to reprocess")
+		return
+	}
+	complete := len(printRequests)
+	logger.Info("found all completed print file requests",
+		zap.Int("complete", complete))
+
+	for _, printRequest := range printRequests {
+		logger.Info("reprocessing print request")
+		if printRequest.Status.Completed {
+			now := time.Now()
+			updated := printRequest.Updated
+			duration := now.Sub(updated)
+			retention := viper.GetInt64("CLEANUP_RETENTION")
+			retentionDuration := time.Duration(retention) * time.Hour
+			if duration  >= retentionDuration {
+				logger.Info("deleting print file request as its older than retention period",
+					zap.Duration("retention", retentionDuration),
+					zap.Duration("duration ", duration))
+				c.store.Delete(printRequest)
+			}
+		} else {
+			logger.Warn("unexpected incomplete print file request during clean up")
+		}
+
+	}
+}

--- a/internal/database/cleanup.go
+++ b/internal/database/cleanup.go
@@ -21,6 +21,7 @@ func (c CleanUp) Start() {
 	for {
 		logger.Info("about to run clean up service")
 		c.store = &DataStore{}
+		c.process()
 		logger.Info("sleeping clean up service",
 			zap.String("delay", delay.String()))
 		time.Sleep(delay)

--- a/internal/database/cleanup.go
+++ b/internal/database/cleanup.go
@@ -51,7 +51,6 @@ func (c CleanUp) process() {
 		zap.Int("complete", complete))
 
 	for _, printRequest := range printRequests {
-		logger.Info("reprocessing print request")
 		if printRequest.Status.Completed {
 			now := time.Now()
 			updated := printRequest.Updated

--- a/internal/database/cleanup.go
+++ b/internal/database/cleanup.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CleanUp struct {
-	store   pkg.Store
+	store pkg.Store
 }
 
 func (c CleanUp) Start() {
@@ -58,7 +58,7 @@ func (c CleanUp) process() {
 			duration := now.Sub(updated)
 			retention := viper.GetInt64("CLEANUP_RETENTION")
 			retentionDuration := time.Duration(retention) * time.Hour
-			if duration  >= retentionDuration {
+			if duration >= retentionDuration {
 				logger.Info("deleting print file request as its older than retention period",
 					zap.Duration("retention", retentionDuration),
 					zap.Duration("duration ", duration))

--- a/internal/database/cleanup_test.go
+++ b/internal/database/cleanup_test.go
@@ -15,15 +15,15 @@ func TestCleanup(t *testing.T) {
 	createdUpdatedTime := time.Now().AddDate(0, 0, -31)
 
 	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   createdUpdatedTime,
-		Updated: createdUpdatedTime,
+		DataFilename:  "test.json",
+		PrintFilename: "test.csv",
+		Created:       createdUpdatedTime,
+		Updated:       createdUpdatedTime,
 		Status: pkg.Status{
 			Templated:    true,
 			UploadedGCS:  true,
 			UploadedSFTP: true,
-			Completed: true,
+			Completed:    true,
 		},
 	}
 
@@ -35,8 +35,8 @@ func TestCleanup(t *testing.T) {
 	store.On("Close").Return(nil)
 	store.On("Delete", printFileRequest).Return(nil)
 
-	cleanUp := CleanUp {
-		store:   store,
+	cleanUp := CleanUp{
+		store: store,
 	}
 	cleanUp.process()
 
@@ -50,15 +50,15 @@ func TestCleanUpDoesNotRunWhenDurationLessThan30days(t *testing.T) {
 	config.SetDefaults()
 
 	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   time.Now(),
-		Updated: time.Now(),
+		DataFilename:  "test.json",
+		PrintFilename: "test.csv",
+		Created:       time.Now(),
+		Updated:       time.Now(),
 		Status: pkg.Status{
 			Templated:    true,
 			UploadedGCS:  true,
 			UploadedSFTP: true,
-			Completed: true,
+			Completed:    true,
 		},
 	}
 
@@ -69,8 +69,8 @@ func TestCleanUpDoesNotRunWhenDurationLessThan30days(t *testing.T) {
 	store.On("FindComplete", mock.Anything, mock.Anything).Return(printFileRequests, nil)
 	store.On("Close").Return(nil)
 
-	cleanUp := CleanUp {
-		store:   store,
+	cleanUp := CleanUp{
+		store: store,
 	}
 	cleanUp.process()
 
@@ -80,20 +80,19 @@ func TestCleanUpDoesNotRunWhenDurationLessThan30days(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-
 func TestCleanUpDoesNotRunWhenNotComplete(t *testing.T) {
 	config.SetDefaults()
 
 	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   time.Now(),
-		Updated: time.Now(),
+		DataFilename:  "test.json",
+		PrintFilename: "test.csv",
+		Created:       time.Now(),
+		Updated:       time.Now(),
 		Status: pkg.Status{
 			Templated:    true,
 			UploadedGCS:  true,
 			UploadedSFTP: false,
-			Completed: false,
+			Completed:    false,
 		},
 	}
 
@@ -104,8 +103,8 @@ func TestCleanUpDoesNotRunWhenNotComplete(t *testing.T) {
 	store.On("FindComplete", mock.Anything, mock.Anything).Return(printFileRequests, nil)
 	store.On("Close").Return(nil)
 
-	cleanUp := CleanUp {
-		store:   store,
+	cleanUp := CleanUp{
+		store: store,
 	}
 	cleanUp.process()
 
@@ -123,8 +122,8 @@ func TestCleanUpDoesNotRunWhenNoResults(t *testing.T) {
 	store.On("FindComplete", mock.Anything, mock.Anything).Return([]*pkg.PrintFileRequest{}, nil)
 	store.On("Close").Return(nil)
 
-	cleanUp := CleanUp {
-		store:   store,
+	cleanUp := CleanUp{
+		store: store,
 	}
 	cleanUp.process()
 

--- a/internal/database/cleanup_test.go
+++ b/internal/database/cleanup_test.go
@@ -1,0 +1,135 @@
+package database
+
+import (
+	"github.com/ONSdigital/ras-rm-print-file/internal/config"
+	mocks "github.com/ONSdigital/ras-rm-print-file/mocks/pkg"
+	"github.com/ONSdigital/ras-rm-print-file/pkg"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+)
+
+func TestCleanup(t *testing.T) {
+	config.SetDefaults()
+
+	createdUpdatedTime := time.Now().AddDate(0, 0, -31)
+
+	printFileRequest := &pkg.PrintFileRequest{
+		DataFilename: "test.json",
+		PrintFilename:  "test.csv",
+		Created:   createdUpdatedTime,
+		Updated: createdUpdatedTime,
+		Status: pkg.Status{
+			Templated:    true,
+			UploadedGCS:  true,
+			UploadedSFTP: true,
+			Completed: true,
+		},
+	}
+
+	printFileRequests := []*pkg.PrintFileRequest{printFileRequest}
+
+	store := new(mocks.Store)
+	store.On("Init").Return(nil)
+	store.On("FindComplete", mock.Anything, mock.Anything).Return(printFileRequests, nil)
+	store.On("Close").Return(nil)
+	store.On("Delete", printFileRequest).Return(nil)
+
+	cleanUp := CleanUp {
+		store:   store,
+	}
+	cleanUp.process()
+
+	store.AssertNotCalled(t, "Update")
+	store.AssertNotCalled(t, "Add")
+	store.AssertExpectations(t)
+
+}
+
+func TestCleanUpDoesNotRunWhenDurationLessThan30days(t *testing.T) {
+	config.SetDefaults()
+
+	printFileRequest := &pkg.PrintFileRequest{
+		DataFilename: "test.json",
+		PrintFilename:  "test.csv",
+		Created:   time.Now(),
+		Updated: time.Now(),
+		Status: pkg.Status{
+			Templated:    true,
+			UploadedGCS:  true,
+			UploadedSFTP: true,
+			Completed: true,
+		},
+	}
+
+	printFileRequests := []*pkg.PrintFileRequest{printFileRequest}
+
+	store := new(mocks.Store)
+	store.On("Init").Return(nil)
+	store.On("FindComplete", mock.Anything, mock.Anything).Return(printFileRequests, nil)
+	store.On("Close").Return(nil)
+
+	cleanUp := CleanUp {
+		store:   store,
+	}
+	cleanUp.process()
+
+	store.AssertNotCalled(t, "Update")
+	store.AssertNotCalled(t, "Add")
+	store.AssertNotCalled(t, "Delete")
+	store.AssertExpectations(t)
+}
+
+
+func TestCleanUpDoesNotRunWhenNotComplete(t *testing.T) {
+	config.SetDefaults()
+
+	printFileRequest := &pkg.PrintFileRequest{
+		DataFilename: "test.json",
+		PrintFilename:  "test.csv",
+		Created:   time.Now(),
+		Updated: time.Now(),
+		Status: pkg.Status{
+			Templated:    true,
+			UploadedGCS:  true,
+			UploadedSFTP: false,
+			Completed: false,
+		},
+	}
+
+	printFileRequests := []*pkg.PrintFileRequest{printFileRequest}
+
+	store := new(mocks.Store)
+	store.On("Init").Return(nil)
+	store.On("FindComplete", mock.Anything, mock.Anything).Return(printFileRequests, nil)
+	store.On("Close").Return(nil)
+
+	cleanUp := CleanUp {
+		store:   store,
+	}
+	cleanUp.process()
+
+	store.AssertNotCalled(t, "Update")
+	store.AssertNotCalled(t, "Add")
+	store.AssertNotCalled(t, "Delete")
+	store.AssertExpectations(t)
+}
+
+func TestCleanUpDoesNotRunWhenNoResults(t *testing.T) {
+	config.SetDefaults()
+
+	store := new(mocks.Store)
+	store.On("Init").Return(nil)
+	store.On("FindComplete", mock.Anything, mock.Anything).Return([]*pkg.PrintFileRequest{}, nil)
+	store.On("Close").Return(nil)
+
+	cleanUp := CleanUp {
+		store:   store,
+	}
+	cleanUp.process()
+
+	store.AssertNotCalled(t, "Update")
+	store.AssertNotCalled(t, "Add")
+	store.AssertNotCalled(t, "Delete")
+	store.AssertExpectations(t)
+}

--- a/internal/database/datastore.go
+++ b/internal/database/datastore.go
@@ -157,7 +157,7 @@ func (s *DataStore) find(complete bool) ([]*pkg.PrintFileRequest, error) {
 		return nil, err
 	}
 	results := len(keys)
-	logger.Info("found  requests", zap.Bool("complete", complete), zap.Int("results", results))
+	logger.Info("found requests", zap.Bool("complete", complete), zap.Int("results", results))
 	for _, v := range keys {
 		logger.Debug("print file request found",
 			zap.Bool("complete", complete),

--- a/internal/database/datastore.go
+++ b/internal/database/datastore.go
@@ -43,7 +43,6 @@ func (s *DataStore) Close() error {
 	return err
 }
 
-
 func (s *DataStore) Add(printFilename string, dataFilename string) (*pkg.PrintFileRequest, error) {
 	if s.client == nil {
 		return nil, errors.New("please initialise the connection")
@@ -171,4 +170,3 @@ func (s *DataStore) FindComplete() ([]*pkg.PrintFileRequest, error) {
 	logger.Debug("finding all complete print file requests")
 	return s.find(true)
 }
-

--- a/internal/gcs/gcs_download_test.go
+++ b/internal/gcs/gcs_download_test.go
@@ -17,4 +17,3 @@ func TestDownloadUploadFileErrorsWithNoConnection(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, printfile)
 }
-

--- a/internal/processor/printer_test.go
+++ b/internal/processor/printer_test.go
@@ -36,7 +36,7 @@ func TestProcess(t *testing.T) {
 
 	gcsDownload := new(mocks.Download)
 	gcsDownload.On("Init").Return(nil)
-	gcsDownload.On("DownloadFile","test.json").Return(printFile, nil)
+	gcsDownload.On("DownloadFile", "test.json").Return(printFile, nil)
 	gcsDownload.On("Close").Return(nil)
 
 	processor := &SDCPrinter{

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -11,9 +11,9 @@ import (
 func TestProcess(t *testing.T) {
 
 	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   time.Now(),
+		DataFilename:  "test.json",
+		PrintFilename: "test.csv",
+		Created:       time.Now(),
 		Status: pkg.Status{
 			Templated:    true,
 			UploadedGCS:  false,
@@ -47,9 +47,9 @@ func TestProcess(t *testing.T) {
 func TestReProcessWhenCompleteDoesNotRun(t *testing.T) {
 
 	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   time.Now(),
+		DataFilename:  "test.json",
+		PrintFilename: "test.csv",
+		Created:       time.Now(),
 		Status: pkg.Status{
 			Templated:    true,
 			UploadedGCS:  true,

--- a/mocks/pkg/Store.go
+++ b/mocks/pkg/Store.go
@@ -49,6 +49,43 @@ func (_m *Store) Close() error {
 	return r0
 }
 
+// Delete provides a mock function with given fields: pfr
+func (_m *Store) Delete(pfr *pkg.PrintFileRequest) error {
+	ret := _m.Called(pfr)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*pkg.PrintFileRequest) error); ok {
+		r0 = rf(pfr)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// FindComplete provides a mock function with given fields:
+func (_m *Store) FindComplete() ([]*pkg.PrintFileRequest, error) {
+	ret := _m.Called()
+
+	var r0 []*pkg.PrintFileRequest
+	if rf, ok := ret.Get(0).(func() []*pkg.PrintFileRequest); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*pkg.PrintFileRequest)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FindIncomplete provides a mock function with given fields:
 func (_m *Store) FindIncomplete() ([]*pkg.PrintFileRequest, error) {
 	ret := _m.Called()

--- a/pkg/interfaces.go
+++ b/pkg/interfaces.go
@@ -5,7 +5,9 @@ type Store interface {
 	Close() error
 	Add(printFilename string, dataFilename string) (*PrintFileRequest, error)
 	Update(pfr *PrintFileRequest) error
+	Delete(pfr *PrintFileRequest) error
 	FindIncomplete() ([]*PrintFileRequest, error)
+	FindComplete() ([]*PrintFileRequest, error)
 }
 
 type Download interface {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -23,12 +23,12 @@ type Contact struct {
 }
 
 type PrintFileRequest struct {
-	DataFilename string
-	PrintFilename  string
-	Created   time.Time
-	Updated   time.Time
-	Status    Status
-	Attempts  int
+	DataFilename  string
+	PrintFilename string
+	Created       time.Time
+	Updated       time.Time
+	Status        Status
+	Attempts      int
 }
 
 type Status struct {


### PR DESCRIPTION
# What and why?
Adding a clean up service to remove old datastore errors. This will run every x hours and delete entries older than y days where x and y are both configurable via helm.

# How to test?
Run in the dev cluster and check the clean up service runs. Any existing Datastore entries older than the retention period will be deleted.

# Trello
https://trello.com/c/s43sNBYB/474-s30-print-file-remove-old-datastore-entries
