### PR TITLE
Log retries

### DIFF
--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.1
 
-appVersion: 1.0.26
+appVersion: 1.0.27

--- a/cmd/ras-rm-print-file/main_test.go
+++ b/cmd/ras-rm-print-file/main_test.go
@@ -12,7 +12,7 @@ func TestConfigure(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal("debug", viper.GetString("LOG_LEVEL"))
-	assert.Equal("ras-rm-printfile", viper.GetString("BUCKET_NAME"))
+	assert.Equal("ras-rm-print-file", viper.GetString("BUCKET_NAME"))
 	assert.Equal("", viper.GetString("BUCKET_PREFIX"))
 	assert.Equal("ras-rm-sandbox", viper.GetString("GOOGLE_CLOUD_PROJECT"))
 	assert.Equal("localhost", viper.GetString("SFTP_HOST"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 
 func SetDefaults() {
 	viper.SetDefault("LOG_LEVEL", "debug")
-	viper.SetDefault("BUCKET_NAME", "ras-rm-printfile")
+	viper.SetDefault("BUCKET_NAME", "ras-rm-print-file")
 	viper.SetDefault("PREFIX_NAME", "")
 	viper.SetDefault("GOOGLE_CLOUD_PROJECT", "ras-rm-sandbox")
 	viper.SetDefault("SFTP_HOST", "localhost")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,7 +12,7 @@ func TestSetDefaults(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal("debug", viper.GetString("LOG_LEVEL"))
-	assert.Equal("ras-rm-printfile", viper.GetString("BUCKET_NAME"))
+	assert.Equal("ras-rm-print-file", viper.GetString("BUCKET_NAME"))
 	assert.Equal("ras-rm-sandbox", viper.GetString("GOOGLE_CLOUD_PROJECT"))
 	assert.Equal("localhost", viper.GetString("SFTP_HOST"))
 	assert.Equal("22", viper.GetString("SFTP_PORT"))

--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -106,11 +106,9 @@ func (p *SDCPrinter) ReProcess(pfr *pkg.PrintFileRequest) error {
 	numberOfAttempts := pfr.Attempts
 	pfr.Attempts = numberOfAttempts + 1
 	// log an error for each retry
-	if pfr.Attempts > 1 {
-		logger.Error("Retried connection",
-			zap.Int("attempts", pfr.Attempts),
-			zap.String("file", pfr.PrintFilename))
-	}
+	logger.Error("Retried connection",
+		zap.Int("attempts", pfr.Attempts),
+		zap.String("file", pfr.PrintFilename))
 
 	// load the data file
 	err := p.gcsDownload.Init()

--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -106,10 +106,11 @@ func (p *SDCPrinter) ReProcess(pfr *pkg.PrintFileRequest) error {
 	// increment the number of attempts
 	numberOfAttempts := pfr.Attempts
 	pfr.Attempts = numberOfAttempts + 1
-	// log an error for every 3 retries
-	if pfr.Attempts % 3 == 0 {
+	// log an error for each retry
+	if pfr.Attempts > 1 {
 		strAttempts := strconv.Itoa(pfr.Attempts)
-		logger.Error("Retried connection " + strAttempts +" times")
+		retryFile := pfr.DataFilename
+		logger.Error("Retried connection " + strAttempts +" times for file " + retryFile)
 	}
 
 	// load the data file

--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"bytes"
 	"os"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -108,9 +107,9 @@ func (p *SDCPrinter) ReProcess(pfr *pkg.PrintFileRequest) error {
 	pfr.Attempts = numberOfAttempts + 1
 	// log an error for each retry
 	if pfr.Attempts > 1 {
-		strAttempts := strconv.Itoa(pfr.Attempts)
-		retryFile := pfr.DataFilename
-		logger.Error("Retried connection " + strAttempts +" times for file " + retryFile)
+		logger.Error("Retried connection",
+			zap.Int("attempts", pfr.Attempts),
+			zap.String("file", pfr.PrintFilename))
 	}
 
 	// load the data file

--- a/internal/processor/printer_test.go
+++ b/internal/processor/printer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"testing"
-	"time"
 )
 
 func TestProcess(t *testing.T) {
@@ -134,27 +133,4 @@ func TestApplyTemplateEmptyPrintFile(t *testing.T) {
 	buffer, err := applyTemplate(printFile)
 	assert.Nil(err)
 	assert.Equal("", buffer.String())
-}
-
-func TestExcessiveRetries(t *testing.T) {
-	assert := assert.New(t)
-	printFileRequest := &pkg.PrintFileRequest{
-		DataFilename: "test.json",
-		PrintFilename:  "test.csv",
-		Created:   time.Now(),
-		Status: pkg.Status{
-			Templated:    true,
-			UploadedGCS:  true,
-			UploadedSFTP: true,
-		},
-	}
-	printFileRequest.Attempts = 3
-	assert.Equal(printFileRequest.Attempts, 3)
-
-	printer := new(mocks.Printer)
-	printer.On("ReProcess", printFileRequest).Return(nil)
-	printer.ReProcess(printFileRequest)
-
-	printer.AssertExpectations(t)
-	printer.AssertCalled(t, "ReProcess", printFileRequest)
 }


### PR DESCRIPTION
# What and why?
Added logging as error for every retry of processing. Errors of this type in Cloud Logging will be used to trigger a a Slack alert, so we know quickly when uploads are failing.

Also fixed a typo in the bucket name in sandbox.
# How to test?
TBD

# Trello
- https://trello.com/c/zLJ7Fzpd/467-s30-add-slack-alert-for-print-file-retries