### PR TITLE
WIP add deliberate fail to test updated Slack alert

### DIFF
--- a/internal/processor/printer.go
+++ b/internal/processor/printer.go
@@ -105,6 +105,7 @@ func (p *SDCPrinter) ReProcess(pfr *pkg.PrintFileRequest) error {
 	// increment the number of attempts
 	numberOfAttempts := pfr.Attempts
 	pfr.Attempts = numberOfAttempts + 1
+	fail fail fail
 	// log an error for each retry
 	logger.Error("Retried connection",
 		zap.Int("attempts", pfr.Attempts),


### PR DESCRIPTION
# What and why?
DO NOT MERGE. Testing updated Slack alert on build fail. 

# How to test?
Check that the fail alerts the correct channel on Slack.

# Trello
- https://trello.com/c/T3vyOTdL/452-move-slack-notifications-to-ras-rm-spinnaker