### PR TITLE
remove print file DLQ and modify topic and subscription names

### DIFF
--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying the rasrm print file generator
 
 type: application
 
-version: 1.0.32
+version: 1.0.33
 
-appVersion: 1.0.32
+appVersion: 1.0.33

--- a/_infra/helm/print-file/values.yaml
+++ b/_infra/helm/print-file/values.yaml
@@ -50,5 +50,5 @@ gcp:
   bucket:
     name: print-file
     prefix: ""
-  topic: print-file-jobs
-  subscription: print-file-workers
+  topic: print-file
+  subscription: print-file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,6 @@ func SetDefaults() {
 	viper.SetDefault("RETRY_DELAY", "3600000")
 	viper.SetDefault("CLEANUP_DELAY", "24")
 	viper.SetDefault("CLEANUP_RETENTION", "720")
-	viper.SetDefault("PUBSUB_SUB_ID", "print-file-workers")
-	viper.SetDefault("PUBSUB_TOPIC", "print-file-jobs")
+	viper.SetDefault("PUBSUB_SUB_ID", "print-file")
+	viper.SetDefault("PUBSUB_TOPIC", "print-file")
 }


### PR DESCRIPTION

# What and why?
remove print file DLQ and modify topic and subscription name to follow convention of other topics and subscription names

# How to test?

# Trello
https://trello.com/c/7vuOMtZG/901-correct-printfile-deadletter-lettering-and-standardise-topic-naming
