### PR TITLE
RAS-1011 Replace unmaintained actions/create-release and update google-github-actions/setup-gcloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker
       - name: pr docker tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,18 +150,11 @@ jobs:
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Create Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/print-file/Chart.yaml
+++ b/_infra/helm/print-file/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for deploying the rasrm print file generator
 
 type: application
 
-version: 1.0.39
+version: 1.0.40
 
-appVersion: 1.0.39
+appVersion: 1.0.40


### PR DESCRIPTION
# What and why?
Replacing the unmaintained create release action with a github command that does the same and updating the setup-gcloud
# How to test?
Check the build
# Jira
https://jira.ons.gov.uk/browse/RAS-1011